### PR TITLE
[update] node to v16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,5 +8,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
I've seen a warning during a github action run.
Maybe it will fix it.
Not tested.

```
Annotations
1 warning
move_card_when_pull_request_merged_job
The following actions uses node12 which is deprecated and will be forced to run on node16: nimbleind/move-trello-card@pr_number. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```